### PR TITLE
New security settings

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -51,6 +51,7 @@ kotlin {
                 implementation(libs.ktor.network)
                 implementation(libs.sqldelight.runtime)
                 implementation(libs.sqldelight.coroutines)
+                implementation(compose.material3)
             }
         }
         val jvmCommonMain by getting {

--- a/composeApp/src/androidMain/kotlin/app/stade/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/app/stade/MainActivity.kt
@@ -6,6 +6,7 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
@@ -30,6 +31,7 @@ class MainActivity : ComponentActivity() {
         )
         super.onCreate(savedInstanceState)
         val app = (application as StadeApplication)
+        applySecureScreenFlag(app)
         startForegroundService(Intent(this, StadeService::class.java))
         askNotificationPermissionIfNeeded()
         handleIncomingInvite(intent)
@@ -44,7 +46,22 @@ class MainActivity : ComponentActivity() {
 
     override fun onResume() {
         super.onResume()
+        // Ayar değişmiş olabilir; her öne geliş anında yeniden uygula
+        val app = (application as StadeApplication)
+        applySecureScreenFlag(app)
         clearAllMessageNotifications()
+    }
+
+    private fun applySecureScreenFlag(app: StadeApplication) {
+        val enabled = app.container?.secrets?.isScreenshotBlockingEnabled() ?: false
+        if (enabled) {
+            window.setFlags(
+                WindowManager.LayoutParams.FLAG_SECURE,
+                WindowManager.LayoutParams.FLAG_SECURE
+            )
+        } else {
+            window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
     }
 
     private fun handleIncomingInvite(intent: Intent?) {

--- a/composeApp/src/androidMain/kotlin/app/stade/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/app/stade/MainActivity.kt
@@ -13,9 +13,12 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
 import app.stade.notification.clearAllMessageNotifications
 import app.stade.service.StadeService
 import app.stade.ui.StadeApp
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
 
@@ -36,6 +39,16 @@ class MainActivity : ComponentActivity() {
         askNotificationPermissionIfNeeded()
         handleIncomingInvite(intent)
         setContent { StadeApp(app.boot) }
+
+        // Ekran görüntüsü engelleme ayarı değiştiğinde (SecuritySettingsScreen'den)
+        // onResume'u beklemeden FLAG_SECURE'ü anında uygula.
+        lifecycleScope.launch {
+            app.containerFlow.collectLatest { container ->
+                container?.screenshotSettingTick?.collect {
+                    applySecureScreenFlag(app)
+                }
+            }
+        }
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -53,7 +66,11 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun applySecureScreenFlag(app: StadeApplication) {
-        val enabled = app.container?.secrets?.isScreenshotBlockingEnabled() ?: false
+        // Vault her zaman StadeApplication.onCreate'de başlatılır; container'ın
+        // (null olabileceği soğuk başlatma dahil) hazır olmasını beklemeden
+        // doğrudan vault'tan okuruz. readMeta şifreli dosyada çalışır,
+        // PIN kilidi açma gerektirmez.
+        val enabled = app.vault.isScreenshotBlockingEnabled()
         // Mevcut durum ile istenen durum aynıysa hiçbir şey yapma.
         // clearFlags/setFlags çağrısı, arka plandan öne geçiş animasyonu sırasında
         // pencere yüzeyini geçici olarak temizleyebilir ve gri ekrana yol açabilir.

--- a/composeApp/src/androidMain/kotlin/app/stade/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/app/stade/MainActivity.kt
@@ -54,13 +54,17 @@ class MainActivity : ComponentActivity() {
 
     private fun applySecureScreenFlag(app: StadeApplication) {
         val enabled = app.container?.secrets?.isScreenshotBlockingEnabled() ?: false
-        if (enabled) {
-            window.setFlags(
+        // Mevcut durum ile istenen durum aynıysa hiçbir şey yapma.
+        // clearFlags/setFlags çağrısı, arka plandan öne geçiş animasyonu sırasında
+        // pencere yüzeyini geçici olarak temizleyebilir ve gri ekrana yol açabilir.
+        val hasSecure = (window.attributes.flags and WindowManager.LayoutParams.FLAG_SECURE) != 0
+        when {
+            enabled && !hasSecure -> window.setFlags(
                 WindowManager.LayoutParams.FLAG_SECURE,
                 WindowManager.LayoutParams.FLAG_SECURE
             )
-        } else {
-            window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+            !enabled && hasSecure -> window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+            // Zaten doğru durumda → dokunma
         }
     }
 

--- a/composeApp/src/androidMain/kotlin/app/stade/ui/screens/PrivacyFeatures.android.kt
+++ b/composeApp/src/androidMain/kotlin/app/stade/ui/screens/PrivacyFeatures.android.kt
@@ -1,0 +1,5 @@
+package app.stade.ui.screens
+
+// Android, FLAG_SECURE ve diğer pencere düzeyinde gizlilik özelliklerini destekler.
+actual val isScreenPrivacySupported: Boolean = true
+

--- a/composeApp/src/commonMain/kotlin/app/stade/AppContainer.kt
+++ b/composeApp/src/commonMain/kotlin/app/stade/AppContainer.kt
@@ -76,7 +76,11 @@ class AppContainer(
     val connections = ConnectionManager(transports, contacts, sync).also {
         sync.selfAddressesProvider = { it.selfAddresses() }
     }
-    val secrets = SecretStore(db, crypto, vault)
+
+    val screenshotSettingTick = MutableStateFlow(0)
+
+    val secrets = SecretStore(db, crypto, vault,
+        onScreenshotSettingChanged = { screenshotSettingTick.value++ })
 
     @Volatile var activeContactId: String? = null
 

--- a/composeApp/src/commonMain/kotlin/app/stade/security/SecretStore.kt
+++ b/composeApp/src/commonMain/kotlin/app/stade/security/SecretStore.kt
@@ -32,6 +32,10 @@ class SecretStore(
 
     fun setSessionTimeoutSeconds(value: Int) = vault.setSessionTimeoutSeconds(value)
 
+    fun isScreenshotBlockingEnabled(): Boolean = vault.isScreenshotBlockingEnabled()
+
+    fun setScreenshotBlockingEnabled(enabled: Boolean) = vault.setScreenshotBlockingEnabled(enabled)
+
     fun failedAttempts(): Int = vault.failedAttempts()
 
     fun lockoutUntilMillis(): Long = vault.lockoutUntilMillis()

--- a/composeApp/src/commonMain/kotlin/app/stade/security/SecretStore.kt
+++ b/composeApp/src/commonMain/kotlin/app/stade/security/SecretStore.kt
@@ -6,7 +6,8 @@ import app.stade.db.StadeDb
 class SecretStore(
     private val db: StadeDb,
     private val crypto: CryptoApi,
-    private val vault: Vault
+    private val vault: Vault,
+    private val onScreenshotSettingChanged: () -> Unit = {}
 ) {
     fun isLockEnabled(): Boolean = vault.isInitialized()
 
@@ -34,7 +35,10 @@ class SecretStore(
 
     fun isScreenshotBlockingEnabled(): Boolean = vault.isScreenshotBlockingEnabled()
 
-    fun setScreenshotBlockingEnabled(enabled: Boolean) = vault.setScreenshotBlockingEnabled(enabled)
+    fun setScreenshotBlockingEnabled(enabled: Boolean) {
+        vault.setScreenshotBlockingEnabled(enabled)
+        onScreenshotSettingChanged()
+    }
 
     fun failedAttempts(): Int = vault.failedAttempts()
 

--- a/composeApp/src/commonMain/kotlin/app/stade/security/Vault.kt
+++ b/composeApp/src/commonMain/kotlin/app/stade/security/Vault.kt
@@ -16,6 +16,8 @@ interface Vault {
     fun setScrambleKeypadEnabled(enabled: Boolean)
     fun sessionTimeoutSeconds(): Int
     fun setSessionTimeoutSeconds(value: Int)
+    fun isScreenshotBlockingEnabled(): Boolean
+    fun setScreenshotBlockingEnabled(enabled: Boolean)
     fun failedAttempts(): Int
     fun lockoutUntilMillis(): Long
     fun nowMillis(): Long

--- a/composeApp/src/commonMain/kotlin/app/stade/ui/StadeApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/stade/ui/StadeApp.kt
@@ -35,6 +35,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import androidx.compose.foundation.lazy.rememberLazyListState
 
 sealed interface Screen {
     data object Onboarding : Screen
@@ -126,6 +127,8 @@ private fun UnlockedApp(
     val scope = rememberCoroutineScope()
     var identity by remember { mutableStateOf<LocalIdentity?>(null) }
     var screen by remember { mutableStateOf<Screen>(Screen.Onboarding) }
+    // Settings scroll pozisyonu: ekranlar arası geçişte kaybolmaması için burada tutulur
+    val settingsListState = rememberLazyListState()
 
     val isInForeground by container.isAppInForeground.collectAsState()
     var leftForegroundAt by remember { mutableStateOf<Long?>(null) }
@@ -231,7 +234,8 @@ private fun UnlockedApp(
                         container.connections.stop()
                         onWipeRequested()
                     }
-                }
+                },
+                listState = settingsListState
             )
             screen == Screen.Security -> SecuritySettingsScreen(
                 container = container,

--- a/composeApp/src/commonMain/kotlin/app/stade/ui/TwoPanelLayout.kt
+++ b/composeApp/src/commonMain/kotlin/app/stade/ui/TwoPanelLayout.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -109,6 +110,8 @@ fun TwoPanelLayout(
     val connectedSet by container.sync.connectedContacts.collectAsState()
     var right by remember { mutableStateOf<PanelRight>(PanelRight.Empty) }
     var query by remember { mutableStateOf("") }
+    // Settings scroll pozisyonu: Settings→Security→Settings geçişinde kaybolmaması için burada tutulur
+    val settingsListState = rememberLazyListState()
 
     val pendingInvite by container.pendingInvite.collectAsState()
     LaunchedEffect(pendingInvite) {
@@ -393,7 +396,8 @@ fun TwoPanelLayout(
                     onBack = { right = PanelRight.Empty },
                     onOpenTransports = { right = PanelRight.Transports },
                     onOpenSecurity = { right = PanelRight.Security },
-                    onLogout = onLogout
+                    onLogout = onLogout,
+                    listState = settingsListState
                 )
 
                 is PanelRight.Security -> SecuritySettingsScreen(

--- a/composeApp/src/commonMain/kotlin/app/stade/ui/i18n/AppStrings.kt
+++ b/composeApp/src/commonMain/kotlin/app/stade/ui/i18n/AppStrings.kt
@@ -169,6 +169,11 @@ abstract class AppStrings {
     abstract fun autoLockSubtitle(label: String): String
     abstract fun sessionTimeoutLabel(seconds: Int): String
 
+    abstract val privacySection: String
+    abstract val screenshotBlockingTitle: String
+    abstract val screenshotBlockingOnSubtitle: String
+    abstract val screenshotBlockingOffSubtitle: String
+
     abstract val transportsTitle: String
     abstract val notRegistered: String
     abstract fun transportRunning(msg: String): String

--- a/composeApp/src/commonMain/kotlin/app/stade/ui/i18n/AppStrings.kt
+++ b/composeApp/src/commonMain/kotlin/app/stade/ui/i18n/AppStrings.kt
@@ -168,6 +168,9 @@ abstract class AppStrings {
     abstract val autoLockTitle: String
     abstract fun autoLockSubtitle(label: String): String
     abstract fun sessionTimeoutLabel(seconds: Int): String
+    abstract val autoLockNeverInfoTitle: String
+    abstract val autoLockNeverInfoBody: String
+    abstract val understood: String
 
     abstract val privacySection: String
     abstract val screenshotBlockingTitle: String

--- a/composeApp/src/commonMain/kotlin/app/stade/ui/i18n/EnglishStrings.kt
+++ b/composeApp/src/commonMain/kotlin/app/stade/ui/i18n/EnglishStrings.kt
@@ -212,7 +212,7 @@ object EnglishStrings : AppStrings() {
     }
 
     override val privacySection = "Privacy"
-    override val screenshotBlockingTitle = "Block recent apps preview"
+    override val screenshotBlockingTitle = "Disable screenshot capture"
     override val screenshotBlockingOnSubtitle = "App content hidden in recent apps; screenshots disabled"
     override val screenshotBlockingOffSubtitle = "App content visible in recent apps"
 

--- a/composeApp/src/commonMain/kotlin/app/stade/ui/i18n/EnglishStrings.kt
+++ b/composeApp/src/commonMain/kotlin/app/stade/ui/i18n/EnglishStrings.kt
@@ -216,6 +216,12 @@ object EnglishStrings : AppStrings() {
     override val screenshotBlockingOnSubtitle = "App content hidden in recent apps; screenshots disabled"
     override val screenshotBlockingOffSubtitle = "App content visible in recent apps"
 
+    override val autoLockNeverInfoTitle = "About the 'Never' Option"
+    override val autoLockNeverInfoBody =
+        "When set to 'Never', no PIN is required when returning to the app from the background.\n\n" +
+        "However, if the app is fully closed and restarted — even if cleared from memory by the system — you will still need to enter your PIN."
+    override val understood = "Got it"
+
     override val transportsTitle = "Transport layers"
     override val notRegistered = "not registered"
     override fun transportRunning(msg: String) = "running · $msg"

--- a/composeApp/src/commonMain/kotlin/app/stade/ui/i18n/EnglishStrings.kt
+++ b/composeApp/src/commonMain/kotlin/app/stade/ui/i18n/EnglishStrings.kt
@@ -211,6 +211,11 @@ object EnglishStrings : AppStrings() {
         else -> if (seconds < 60) "$seconds seconds" else "${seconds / 60} minutes"
     }
 
+    override val privacySection = "Privacy"
+    override val screenshotBlockingTitle = "Block recent apps preview"
+    override val screenshotBlockingOnSubtitle = "App content hidden in recent apps; screenshots disabled"
+    override val screenshotBlockingOffSubtitle = "App content visible in recent apps"
+
     override val transportsTitle = "Transport layers"
     override val notRegistered = "not registered"
     override fun transportRunning(msg: String) = "running · $msg"

--- a/composeApp/src/commonMain/kotlin/app/stade/ui/i18n/TurkishStrings.kt
+++ b/composeApp/src/commonMain/kotlin/app/stade/ui/i18n/TurkishStrings.kt
@@ -217,6 +217,12 @@ object TurkishStrings : AppStrings() {
     override val screenshotBlockingOnSubtitle = "Uygulama içeriği son uygulamalar'da gizlenir; ekran görüntüsü alınamaz"
     override val screenshotBlockingOffSubtitle = "Uygulama içeriği son uygulamalar'da görünür"
 
+    override val autoLockNeverInfoTitle = "«Asla» Seçeneği Hakkında"
+    override val autoLockNeverInfoBody =
+        "«Asla» seçildiğinde, uygulama arka planda çalışırken öne alındığında PIN istenmez.\n\n" +
+        "Ancak uygulama tamamen kapatılıp yeniden açıldığında — sistem tarafından bellekten temizlenmiş olsa dahi — şifrenizi girmeniz gerekir."
+    override val understood = "Anladım"
+
     override val transportsTitle = "Taşıma katmanları"
     override val notRegistered = "kayıtlı değil"
     override fun transportRunning(msg: String) = "çalışıyor · $msg"

--- a/composeApp/src/commonMain/kotlin/app/stade/ui/i18n/TurkishStrings.kt
+++ b/composeApp/src/commonMain/kotlin/app/stade/ui/i18n/TurkishStrings.kt
@@ -213,7 +213,7 @@ object TurkishStrings : AppStrings() {
     }
 
     override val privacySection = "Gizlilik"
-    override val screenshotBlockingTitle = "Son uygulamalar önizlemesini gizle"
+    override val screenshotBlockingTitle = "Ekran görüntüsü almayı devre dışı bırak"
     override val screenshotBlockingOnSubtitle = "Uygulama içeriği son uygulamalar'da gizlenir; ekran görüntüsü alınamaz"
     override val screenshotBlockingOffSubtitle = "Uygulama içeriği son uygulamalar'da görünür"
 

--- a/composeApp/src/commonMain/kotlin/app/stade/ui/i18n/TurkishStrings.kt
+++ b/composeApp/src/commonMain/kotlin/app/stade/ui/i18n/TurkishStrings.kt
@@ -212,6 +212,11 @@ object TurkishStrings : AppStrings() {
         else -> if (seconds < 60) "$seconds saniye" else "${seconds / 60} dakika"
     }
 
+    override val privacySection = "Gizlilik"
+    override val screenshotBlockingTitle = "Son uygulamalar önizlemesini gizle"
+    override val screenshotBlockingOnSubtitle = "Uygulama içeriği son uygulamalar'da gizlenir; ekran görüntüsü alınamaz"
+    override val screenshotBlockingOffSubtitle = "Uygulama içeriği son uygulamalar'da görünür"
+
     override val transportsTitle = "Taşıma katmanları"
     override val notRegistered = "kayıtlı değil"
     override fun transportRunning(msg: String) = "çalışıyor · $msg"

--- a/composeApp/src/commonMain/kotlin/app/stade/ui/screens/PrivacyFeatures.kt
+++ b/composeApp/src/commonMain/kotlin/app/stade/ui/screens/PrivacyFeatures.kt
@@ -1,0 +1,13 @@
+package app.stade.ui.screens
+
+/**
+ * Platforma özgü gizlilik özelliklerinin desteklenip desteklenmediğini bildirir.
+ *
+ * Android: FLAG_SECURE gibi pencere düzeyinde ekran koruma özelliklerini destekler → true
+ * Desktop: Bu özellikler pencere sistemi tarafından sağlanmadığından desteklenmez → false
+ *
+ * İleride masaüstüne özgü gizlilik ayarları eklendikçe bu değer veya ek expect tanımları
+ * bu dosyaya eklenmelidir.
+ */
+expect val isScreenPrivacySupported: Boolean
+

--- a/composeApp/src/commonMain/kotlin/app/stade/ui/screens/SecuritySettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/stade/ui/screens/SecuritySettingsScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Fingerprint
 import androidx.compose.material.icons.filled.Grid3x3
 import androidx.compose.material.icons.filled.Timer
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DropdownMenu
@@ -33,6 +34,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -53,6 +55,7 @@ import app.stade.security.SessionTimeout
 import app.stade.ui.components.PlatformVerticalScrollbar
 import app.stade.ui.i18n.LocalStrings
 
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SecuritySettingsScreen(
@@ -64,6 +67,7 @@ fun SecuritySettingsScreen(
     var refreshTick by remember { mutableStateOf(0) }
     val scrambleEnabled = remember(refreshTick) { container.secrets.isScrambleKeypadEnabled() }
     val sessionTimeout = remember(refreshTick) { container.secrets.sessionTimeoutSeconds() }
+    val screenshotBlockingEnabled = remember(refreshTick) { container.secrets.isScreenshotBlockingEnabled() }
     var timeoutMenuOpen by remember { mutableStateOf(false) }
     val listState = rememberLazyListState()
 
@@ -98,25 +102,55 @@ fun SecuritySettingsScreen(
                             tint = MaterialTheme.colorScheme.primary,
                             title = strings.changePinTitle,
                             subtitle = strings.changePinSubtitle,
-                            onClick = { onOpenPinSetup(true) }
+                            onClick = { onOpenPinSetup(true) },
+                            modifier = Modifier
+                                .padding(bottom = 2.dp) // Kartı fiziksel olarak aşağı iter
+                                .background(
+                                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                                    shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp, bottomStart = 4.dp, bottomEnd = 4.dp)
+                                )
+                                .clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp, bottomStart = 4.dp, bottomEnd = 4.dp))
                         )
-                        HorizontalDivider(
-                            modifier = Modifier.padding(horizontal = 16.dp),
-                            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
-                        )
+
                         SecuritySwitchRow(
                             icon = Icons.Default.Grid3x3,
                             tint = MaterialTheme.colorScheme.tertiary,
                             title = strings.scrambleKeypadTitle,
-                            subtitle = if (scrambleEnabled)
-                                strings.scrambleKeypadOnSubtitle
-                            else
-                                strings.scrambleKeypadOffSubtitle,
+                            subtitle = if (scrambleEnabled) strings.scrambleKeypadOnSubtitle else strings.scrambleKeypadOffSubtitle,
                             checked = scrambleEnabled,
                             onCheckedChange = {
                                 container.secrets.setScrambleKeypadEnabled(it)
                                 refreshTick++
-                            }
+                            },
+                            modifier = Modifier
+                                .background(
+                                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                                    shape = RoundedCornerShape(topStart = 4.dp, topEnd = 4.dp, bottomStart = 16.dp, bottomEnd = 16.dp)
+                                )
+                                .clip(RoundedCornerShape(topStart = 4.dp, topEnd = 4.dp, bottomStart = 16.dp, bottomEnd = 16.dp))
+                        )
+                    }
+                }
+
+                item {
+                    SecuritySectionLabel(strings.privacySection)
+                    SecurityGroup {
+                        SecuritySwitchRow(
+                            icon = Icons.Default.VisibilityOff,
+                            tint = MaterialTheme.colorScheme.secondary,
+                            title = strings.screenshotBlockingTitle,
+                            subtitle = if (screenshotBlockingEnabled) strings.screenshotBlockingOnSubtitle else strings.screenshotBlockingOffSubtitle,
+                            checked = screenshotBlockingEnabled,
+                            onCheckedChange = {
+                                container.secrets.setScreenshotBlockingEnabled(it)
+                                refreshTick++
+                            },
+                            modifier = Modifier
+                                .background(
+                                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                                    shape = MaterialTheme.shapes.large
+                                )
+                                .clip(MaterialTheme.shapes.large)
                         )
                     }
                 }
@@ -130,7 +164,15 @@ fun SecuritySettingsScreen(
                                 tint = MaterialTheme.colorScheme.secondary,
                                 title = strings.autoLockTitle,
                                 subtitle = strings.autoLockSubtitle(strings.sessionTimeoutLabel(sessionTimeout)),
-                                onClick = { timeoutMenuOpen = true }
+                                onClick = { timeoutMenuOpen = true },
+                                // DÜZELTME: Bu tek başına duran bir kart olduğu için tüm köşelerini
+                                // orijinal halindeki gibi (MaterialTheme.shapes.large) eşit derecede oval yapıyoruz.
+                                modifier = Modifier
+                                    .background(
+                                        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                                        shape = MaterialTheme.shapes.large
+                                    )
+                                    .clip(MaterialTheme.shapes.large)
                             )
                             DropdownMenu(
                                 expanded = timeoutMenuOpen,
@@ -174,14 +216,16 @@ private fun SecuritySectionLabel(title: String) {
     )
 }
 
+// Eski SecurityGroup fonksiyonunu tamamen bununla değiştir:
 @Composable
 private fun SecurityGroup(content: @Composable () -> Unit) {
-    Card(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
-        shape = MaterialTheme.shapes.large,
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
-        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
-    ) { content() }
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+    ) {
+        content()
+    }
 }
 
 @Composable
@@ -190,10 +234,16 @@ private fun SecurityNavRow(
     tint: Color,
     title: String,
     subtitle: String? = null,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Row(
-        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick).padding(horizontal = 16.dp, vertical = 14.dp),
+        // Düzenlenen kısım: modifier'ı clickable ve iç padding'in önünde konumlandırdık
+        modifier = Modifier
+            .fillMaxWidth()
+            .then(modifier) // Dışarıdan gelen clip ve padding buraya enjekte olur
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 14.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         SecurityIconBox(icon, tint)
@@ -215,10 +265,16 @@ private fun SecuritySwitchRow(
     title: String,
     subtitle: String?,
     checked: Boolean,
-    onCheckedChange: (Boolean) -> Unit
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Row(
-        modifier = Modifier.fillMaxWidth().clickable { onCheckedChange(!checked) }.padding(horizontal = 16.dp, vertical = 14.dp),
+        // Düzenlenen kısım: Aynı zincirleme mantığı Switch için de geçerli
+        modifier = Modifier
+            .fillMaxWidth()
+            .then(modifier)
+            .clickable { onCheckedChange(!checked) }
+            .padding(horizontal = 16.dp, vertical = 14.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         SecurityIconBox(icon, tint)

--- a/composeApp/src/commonMain/kotlin/app/stade/ui/screens/SecuritySettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/stade/ui/screens/SecuritySettingsScreen.kt
@@ -283,22 +283,38 @@ private fun SecurityNavRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .then(modifier)
-            .clickable(onClick = onClick)
-            .padding(horizontal = 16.dp, vertical = 14.dp),
+            .then(modifier),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        SecurityIconBox(icon, tint)
-        Spacer(Modifier.width(14.dp))
-        Column(Modifier.weight(1f)) {
-            Text(title, style = MaterialTheme.typography.bodyLarge)
-            if (subtitle != null) {
-                Spacer(Modifier.height(2.dp))
-                Text(subtitle, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Row(
+            modifier = Modifier
+                .weight(1f)
+                .clickable(onClick = onClick)
+                .padding(
+                    start = 16.dp,
+                    top = 14.dp,
+                    bottom = 14.dp,
+                    end = if (trailingContent != null) 4.dp else 16.dp
+                ),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            SecurityIconBox(icon, tint)
+            Spacer(Modifier.width(14.dp))
+            Column {
+                Text(title, style = MaterialTheme.typography.bodyLarge)
+                if (subtitle != null) {
+                    Spacer(Modifier.height(2.dp))
+                    Text(subtitle, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
             }
         }
         if (trailingContent != null) {
-            trailingContent()
+            Box(
+                modifier = Modifier.padding(end = 8.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                trailingContent()
+            }
         }
     }
 }
@@ -314,7 +330,6 @@ private fun SecuritySwitchRow(
     modifier: Modifier = Modifier
 ) {
     Row(
-        // Düzenlenen kısım: Aynı zincirleme mantığı Switch için de geçerli
         modifier = Modifier
             .fillMaxWidth()
             .then(modifier)

--- a/composeApp/src/commonMain/kotlin/app/stade/ui/screens/SecuritySettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/stade/ui/screens/SecuritySettingsScreen.kt
@@ -22,8 +22,10 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Fingerprint
 import androidx.compose.material.icons.filled.Grid3x3
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DropdownMenu
@@ -37,6 +39,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -69,6 +72,7 @@ fun SecuritySettingsScreen(
     val sessionTimeout = remember(refreshTick) { container.secrets.sessionTimeoutSeconds() }
     val screenshotBlockingEnabled = remember(refreshTick) { container.secrets.isScreenshotBlockingEnabled() }
     var timeoutMenuOpen by remember { mutableStateOf(false) }
+    var showNeverInfoDialog by remember { mutableStateOf(false) }
     val listState = rememberLazyListState()
 
     Scaffold(
@@ -170,14 +174,22 @@ fun SecuritySettingsScreen(
                                 title = strings.autoLockTitle,
                                 subtitle = strings.autoLockSubtitle(strings.sessionTimeoutLabel(sessionTimeout)),
                                 onClick = { timeoutMenuOpen = true },
-                                // DÜZELTME: Bu tek başına duran bir kart olduğu için tüm köşelerini
-                                // orijinal halindeki gibi (MaterialTheme.shapes.large) eşit derecede oval yapıyoruz.
                                 modifier = Modifier
                                     .background(
                                         color = MaterialTheme.colorScheme.surfaceContainerHigh,
                                         shape = MaterialTheme.shapes.large
                                     )
-                                    .clip(MaterialTheme.shapes.large)
+                                    .clip(MaterialTheme.shapes.large),
+                                trailingContent = {
+                                    IconButton(onClick = { showNeverInfoDialog = true }) {
+                                        Icon(
+                                            Icons.Default.Info,
+                                            contentDescription = strings.autoLockNeverInfoTitle,
+                                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                                            modifier = Modifier.size(20.dp)
+                                        )
+                                    }
+                                }
                             )
                             DropdownMenu(
                                 expanded = timeoutMenuOpen,
@@ -202,6 +214,31 @@ fun SecuritySettingsScreen(
                         }
                     }
                 }
+            }
+
+            if (showNeverInfoDialog) {
+                AlertDialog(
+                    onDismissRequest = { showNeverInfoDialog = false },
+                    icon = {
+                        Icon(
+                            Icons.Default.Info,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                    },
+                    title = { Text(strings.autoLockNeverInfoTitle) },
+                    text = {
+                        Text(
+                            strings.autoLockNeverInfoBody,
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                    },
+                    confirmButton = {
+                        TextButton(onClick = { showNeverInfoDialog = false }) {
+                            Text(strings.understood)
+                        }
+                    }
+                )
             }
             PlatformVerticalScrollbar(
                 state = listState,
@@ -240,13 +277,13 @@ private fun SecurityNavRow(
     title: String,
     subtitle: String? = null,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    trailingContent: (@Composable () -> Unit)? = null
 ) {
     Row(
-        // Düzenlenen kısım: modifier'ı clickable ve iç padding'in önünde konumlandırdık
         modifier = Modifier
             .fillMaxWidth()
-            .then(modifier) // Dışarıdan gelen clip ve padding buraya enjekte olur
+            .then(modifier)
             .clickable(onClick = onClick)
             .padding(horizontal = 16.dp, vertical = 14.dp),
         verticalAlignment = Alignment.CenterVertically
@@ -259,6 +296,9 @@ private fun SecurityNavRow(
                 Spacer(Modifier.height(2.dp))
                 Text(subtitle, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
+        }
+        if (trailingContent != null) {
+            trailingContent()
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/stade/ui/screens/SecuritySettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/stade/ui/screens/SecuritySettingsScreen.kt
@@ -104,14 +104,13 @@ fun SecuritySettingsScreen(
                             subtitle = strings.changePinSubtitle,
                             onClick = { onOpenPinSetup(true) },
                             modifier = Modifier
-                                .padding(bottom = 2.dp) // Kartı fiziksel olarak aşağı iter
+                                .padding(bottom = 2.dp)
                                 .background(
                                     color = MaterialTheme.colorScheme.surfaceContainerHigh,
                                     shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp, bottomStart = 4.dp, bottomEnd = 4.dp)
                                 )
                                 .clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp, bottomStart = 4.dp, bottomEnd = 4.dp))
                         )
-
                         SecuritySwitchRow(
                             icon = Icons.Default.Grid3x3,
                             tint = MaterialTheme.colorScheme.tertiary,
@@ -132,26 +131,32 @@ fun SecuritySettingsScreen(
                     }
                 }
 
-                item {
-                    SecuritySectionLabel(strings.privacySection)
-                    SecurityGroup {
-                        SecuritySwitchRow(
-                            icon = Icons.Default.VisibilityOff,
-                            tint = MaterialTheme.colorScheme.secondary,
-                            title = strings.screenshotBlockingTitle,
-                            subtitle = if (screenshotBlockingEnabled) strings.screenshotBlockingOnSubtitle else strings.screenshotBlockingOffSubtitle,
-                            checked = screenshotBlockingEnabled,
-                            onCheckedChange = {
-                                container.secrets.setScreenshotBlockingEnabled(it)
-                                refreshTick++
-                            },
-                            modifier = Modifier
-                                .background(
-                                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
-                                    shape = MaterialTheme.shapes.large
-                                )
-                                .clip(MaterialTheme.shapes.large)
-                        )
+                // Gizlilik bölümü yalnızca desteklenen platformlarda gösterilir (Android).
+                // Masaüstünde FLAG_SECURE ve benzeri özellikler desteklenmediğinden gizlenir.
+                // İleride masaüstüne özgü gizlilik ayarları eklendikçe PrivacyFeatures.kt
+                // güncellenerek bu blok otomatik olarak görünür hale gelir.
+                if (isScreenPrivacySupported) {
+                    item {
+                        SecuritySectionLabel(strings.privacySection)
+                        SecurityGroup {
+                            SecuritySwitchRow(
+                                icon = Icons.Default.VisibilityOff,
+                                tint = MaterialTheme.colorScheme.secondary,
+                                title = strings.screenshotBlockingTitle,
+                                subtitle = if (screenshotBlockingEnabled) strings.screenshotBlockingOnSubtitle else strings.screenshotBlockingOffSubtitle,
+                                checked = screenshotBlockingEnabled,
+                                onCheckedChange = {
+                                    container.secrets.setScreenshotBlockingEnabled(it)
+                                    refreshTick++
+                                },
+                                modifier = Modifier
+                                    .background(
+                                        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                                        shape = MaterialTheme.shapes.large
+                                    )
+                                    .clip(MaterialTheme.shapes.large)
+                            )
+                        }
                     }
                 }
 

--- a/composeApp/src/commonMain/kotlin/app/stade/ui/screens/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/stade/ui/screens/SettingsScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Fingerprint
 import androidx.compose.material.icons.filled.Grid3x3
 import androidx.compose.material.icons.filled.Lock
-import androidx.compose.material.icons.filled.LockOpen
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.NotificationsOff
 import androidx.compose.material.icons.filled.OpenInNew
@@ -45,7 +44,6 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -254,7 +252,22 @@ fun SettingsScreen(
             if (isNotificationSupported) {
                 item {
                     SettingsSectionLabel(strings.notificationsSection)
-                    SettingsGroup {
+                    val bgColor = MaterialTheme.colorScheme.surfaceContainerHigh
+                    val shapeTop = RoundedCornerShape(
+                        topStart = 16.dp, topEnd = 16.dp,
+                        bottomStart = 4.dp, bottomEnd = 4.dp
+                    )
+                    val shapeMid = RoundedCornerShape(4.dp)
+                    val shapeBot = RoundedCornerShape(
+                        topStart = 4.dp, topEnd = 4.dp,
+                        bottomStart = 16.dp, bottomEnd = 16.dp
+                    )
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp)
+                    ) {
+                        // ── Bildirimler toggle — her zaman en üstte ──────
                         SwitchSettingsRow(
                             icon = if (notificationsEnabled) Icons.Default.Notifications
                                    else Icons.Default.NotificationsOff,
@@ -264,13 +277,14 @@ fun SettingsScreen(
                             subtitle = if (notificationsEnabled) strings.notificationsOnSubtitle
                                        else strings.notificationsOffSubtitle,
                             checked = notificationsEnabled,
-                            onCheckedChange = { setNotificationsEnabled(it) }
+                            onCheckedChange = { setNotificationsEnabled(it) },
+                            modifier = Modifier
+                                .padding(bottom = 2.dp)
+                                .background(color = bgColor, shape = shapeTop)
+                                .clip(shapeTop)
                         )
+                        // ── Gizlilik toggle — yalnızca bildirimler açıkken ──
                         if (notificationsEnabled) {
-                            HorizontalDivider(
-                                modifier = Modifier.padding(horizontal = 16.dp),
-                                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
-                            )
                             SwitchSettingsRow(
                                 icon = Icons.Default.VisibilityOff,
                                 iconTint = MaterialTheme.colorScheme.tertiary,
@@ -280,19 +294,23 @@ fun SettingsScreen(
                                 else
                                     strings.visibleNotificationSubtitle,
                                 checked = notificationPrivacyEnabled,
-                                onCheckedChange = { setNotificationPrivacyEnabled(it) }
+                                onCheckedChange = { setNotificationPrivacyEnabled(it) },
+                                modifier = Modifier
+                                    .padding(bottom = 2.dp)
+                                    .background(color = bgColor, shape = shapeMid)
+                                    .clip(shapeMid)
                             )
                         }
-                        HorizontalDivider(
-                            modifier = Modifier.padding(horizontal = 16.dp),
-                            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
-                        )
+                        // ── Sistem bildirimleri — her zaman en altta ──────
                         NavigationSettingsRow(
                             icon = Icons.Default.OpenInNew,
                             iconTint = MaterialTheme.colorScheme.secondary,
                             title = strings.systemNotificationsTitle,
                             subtitle = strings.systemNotificationsSubtitle,
-                            onClick = { openNotificationSettings() }
+                            onClick = { openNotificationSettings() },
+                            modifier = Modifier
+                                .background(color = bgColor, shape = shapeBot)
+                                .clip(shapeBot)
                         )
                     }
                 }
@@ -480,11 +498,13 @@ private fun SwitchSettingsRow(
     title: String,
     subtitle: String? = null,
     checked: Boolean,
-    onCheckedChange: (Boolean) -> Unit
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .then(modifier)
             .clickable { onCheckedChange(!checked) }
             .padding(horizontal = 16.dp, vertical = 14.dp),
         verticalAlignment = Alignment.CenterVertically
@@ -513,11 +533,13 @@ private fun NavigationSettingsRow(
     iconTint: Color,
     title: String,
     subtitle: String? = null,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .then(modifier)
             .clickable(onClick = onClick)
             .padding(horizontal = 16.dp, vertical = 14.dp),
         verticalAlignment = Alignment.CenterVertically

--- a/composeApp/src/commonMain/kotlin/app/stade/ui/screens/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/stade/ui/screens/SettingsScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -96,7 +97,8 @@ fun SettingsScreen(
     onBack: () -> Unit,
     onOpenTransports: () -> Unit,
     onOpenSecurity: () -> Unit = {},
-    onLogout: () -> Unit
+    onLogout: () -> Unit,
+    listState: LazyListState = rememberLazyListState()
 ) {
     val strings = LocalStrings.current
     val fingerprint = remember(owner.id) { container.fingerprint.fingerprint(owner.publicSigningKey) }
@@ -165,7 +167,6 @@ fun SettingsScreen(
             )
         }
     ) { padding ->
-        val listState = rememberLazyListState()
         Box(modifier = Modifier.fillMaxSize().padding(padding)) {
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),

--- a/composeApp/src/desktopMain/kotlin/app/stade/ui/screens/PrivacyFeatures.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/app/stade/ui/screens/PrivacyFeatures.desktop.kt
@@ -1,0 +1,6 @@
+package app.stade.ui.screens
+
+// Masaüstünde FLAG_SECURE ve benzeri pencere gizlilik özellikleri desteklenmez.
+// İleride masaüstüne özgü gizlilik ayarları eklendiğinde bu değer true yapılabilir.
+actual val isScreenPrivacySupported: Boolean = false
+

--- a/composeApp/src/jvmCommonMain/kotlin/app/stade/security/FileVault.kt
+++ b/composeApp/src/jvmCommonMain/kotlin/app/stade/security/FileVault.kt
@@ -15,6 +15,7 @@ class FileVault(private val rootDir: File) : Vault {
     private val metaFile: File = File(rootDir, "stade.vault")
     private val encryptedDb: File = File(rootDir, "stade.db.enc")
     private val plaintextDb: File = File(rootDir, "stade.db")
+    // sessionFile: session-file mekanizması kaldırıldı; yalnızca eski dosyaları temizlemek için referans.
     private val sessionFile: File = File(rootDir, "stade.session")
 
     private val rng = SecureRandom()
@@ -134,7 +135,7 @@ class FileVault(private val rootDir: File) : Vault {
             }
         }
         unlocked = true
-        syncSessionFile(meta)
+        syncSessionFile()
         return UnlockOutcome.Success
     }
 
@@ -245,7 +246,7 @@ class FileVault(private val rootDir: File) : Vault {
         meta.sessionTimeoutSeconds = value
         writeMeta(meta)
         cached = meta
-        syncSessionFile(meta)
+        syncSessionFile()
     }
 
     override fun isScreenshotBlockingEnabled(): Boolean =
@@ -342,8 +343,10 @@ class FileVault(private val rootDir: File) : Vault {
     private fun readMeta(): Meta? {
         if (!metaFile.exists()) return null
         val bytes = runCatching { metaFile.readBytes() }.getOrNull() ?: return null
-        // MIN_META_SIZE - 1 = eski vault formatı (screenshotBlocking baytı olmadan); geriye dönük uyum
-        if (bytes.size < MIN_META_SIZE - 1) return null
+        // MIN_META_SIZE_LEGACY = eski vault formatı (screenshotBlocking baytı olmadan);
+        // geriye dönük uyum için bu sabit kullanılır — ileride yeni alanlar eklenirse
+        // yalnızca MIN_META_SIZE_LEGACY tanımı güncellenir, bu satır değişmez.
+        if (bytes.size < MIN_META_SIZE_LEGACY) return null
         val buf = ByteBuffer.wrap(bytes)
         val magic = ByteArray(4).also { buf.get(it) }
         if (!magic.contentEquals(META_MAGIC)) return null
@@ -405,68 +408,13 @@ class FileVault(private val rootDir: File) : Vault {
         for (i in b.indices) b[i] = 0
     }
 
-    private fun syncSessionFile(meta: Meta) {
+    private fun syncSessionFile() {
         // Session dosyası mekanizması artık kullanılmıyor.
         // "Asla" kilit: arka plan koruması process'in bellekte canlı olmasına dayanır,
         // kalıcı dosyaya değil. Mevcut dosya varsa güvenlik gereği temizle.
-        @Suppress("UNUSED_PARAMETER")
         if (sessionFile.exists()) runCatching { secureDelete(sessionFile) }
     }
 
-    private fun writeSessionDek(plaintextDek: ByteArray) {
-        val salt = ByteArray(SALT_LEN).also { rng.nextBytes(it) }
-        val machineKey = deriveMachineKey(salt)
-        val nonce = ByteArray(NONCE_LEN).also { rng.nextBytes(it) }
-        val ct = gcmEncrypt(machineKey, nonce, plaintextDek)
-        zero(machineKey)
-        val out = ByteArray(4 + 1 + SALT_LEN + NONCE_LEN + ct.size)
-        val buf = ByteBuffer.wrap(out)
-        buf.put(SESSION_MAGIC)
-        buf.put(SESSION_VERSION)
-        buf.put(salt)
-        buf.put(nonce)
-        buf.put(ct)
-        val tmp = File(sessionFile.parentFile, sessionFile.name + ".tmp")
-        tmp.writeBytes(out)
-        if (sessionFile.exists()) sessionFile.delete()
-        if (!tmp.renameTo(sessionFile)) {
-            tmp.copyTo(sessionFile, overwrite = true)
-            tmp.delete()
-        }
-    }
-
-    private fun readSessionDek(): ByteArray {
-        val bytes = sessionFile.readBytes()
-        require(bytes.size >= 4 + 1 + SALT_LEN + NONCE_LEN + DEK_CT_LEN) { "session corrupt" }
-        val buf = ByteBuffer.wrap(bytes)
-        val magic = ByteArray(4).also { buf.get(it) }
-        require(magic.contentEquals(SESSION_MAGIC)) { "session magic" }
-        val version = buf.get()
-        require(version == SESSION_VERSION) { "session version" }
-        val salt = ByteArray(SALT_LEN).also { buf.get(it) }
-        val nonce = ByteArray(NONCE_LEN).also { buf.get(it) }
-        val ct = ByteArray(bytes.size - (4 + 1 + SALT_LEN + NONCE_LEN)).also { buf.get(it) }
-        val machineKey = deriveMachineKey(salt)
-        val pt = gcmDecrypt(machineKey, nonce, ct)
-        zero(machineKey)
-        return pt
-    }
-
-    private fun deriveMachineKey(salt: ByteArray): ByteArray {
-        val parts = listOf(
-            System.getProperty("user.name") ?: "",
-            System.getProperty("user.home") ?: "",
-            System.getProperty("os.name") ?: "",
-            System.getProperty("os.arch") ?: "",
-            "stade-machine-binding-v1"
-        )
-        val secret = parts.joinToString(separator = "\u0000")
-        val spec = PBEKeySpec(secret.toCharArray(), salt, MACHINE_KDF_ITERS, KEY_BITS)
-        val factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256")
-        val encoded = factory.generateSecret(spec).encoded
-        spec.clearPassword()
-        return encoded
-    }
 
     private fun secureDelete(f: File) {
         try {
@@ -507,12 +455,11 @@ class FileVault(private val rootDir: File) : Vault {
         // bu değişiklik yalnızca yeni kurulumları ve şifre değişikliklerini etkiler;
         // eski vault'lar güvenle açılmaya devam eder.
         private const val KDF_ITERS = 600_000
-        private const val MACHINE_KDF_ITERS = 4_000
         private const val LOCKOUT_THRESHOLD = 5
-        private val SESSION_MAGIC = byteArrayOf('S'.code.toByte(), 'T'.code.toByte(), 'D'.code.toByte(), 'S'.code.toByte())
-        private const val SESSION_VERSION: Byte = 0x01
         private const val MIN_META_SIZE =
             4 + 1 + SALT_LEN + 4 + NONCE_LEN + VERIFIER_CT_LEN + NONCE_LEN + DEK_CT_LEN + 4 + 8 + 1 + 4 + 1
+
+        private const val MIN_META_SIZE_LEGACY = MIN_META_SIZE - 1 // screenshotBlocking baytı yok
         private val VERIFIER_PLAIN = byteArrayOf(
             'S'.code.toByte(), 'T'.code.toByte(), 'A'.code.toByte(), 'D'.code.toByte(),
             'E'.code.toByte(), '-'.code.toByte(), 'V'.code.toByte(), 'E'.code.toByte(),

--- a/composeApp/src/jvmCommonMain/kotlin/app/stade/security/FileVault.kt
+++ b/composeApp/src/jvmCommonMain/kotlin/app/stade/security/FileVault.kt
@@ -139,25 +139,16 @@ class FileVault(private val rootDir: File) : Vault {
     }
 
     override fun tryAutoUnlock(): Boolean {
+        // Session dosyası mekanizması kaldırıldı.
+        // "Asla" kilit zaman aşımı artık yalnızca bellek tabanlıdır:
+        //   • Uygulama arka planda çalışırken dönüldüğünde FileVault.unlocked == true,
+        //     bu nedenle ilk satır true döner → PIN istenmez.
+        //   • Uygulama tamamen kapatılıp yeniden başlatıldığında yeni bir FileVault
+        //     örneği oluşur ve unlocked == false olur → aşağıda false döner → PIN istenir.
         if (unlocked) return true
-        if (!isInitialized()) return false
-        val meta = readMeta() ?: return false
-        if (meta.sessionTimeoutSeconds != SessionTimeout.NEVER) {
-            if (sessionFile.exists()) runCatching { secureDelete(sessionFile) }
-            return false
-        }
-        if (!sessionFile.exists()) return false
-        val recoveredDek = runCatching { readSessionDek() }.getOrNull() ?: run {
-            runCatching { secureDelete(sessionFile) }
-            return false
-        }
-        dek = recoveredDek
-        cached = meta
-        if (!plaintextDb.exists() && encryptedDb.exists()) {
-            runCatching { decryptFile(encryptedDb, plaintextDb, recoveredDek) }
-        }
-        unlocked = true
-        return true
+        // Eski bir session dosyası kalmışsa güvenli şekilde sil.
+        if (sessionFile.exists()) runCatching { secureDelete(sessionFile) }
+        return false
     }
 
     override fun changePassword(currentPassword: String, newPassword: String): Boolean {
@@ -415,12 +406,11 @@ class FileVault(private val rootDir: File) : Vault {
     }
 
     private fun syncSessionFile(meta: Meta) {
-        val key = dek
-        if (meta.sessionTimeoutSeconds == SessionTimeout.NEVER && key != null) {
-            runCatching { writeSessionDek(key) }
-        } else if (sessionFile.exists()) {
-            runCatching { secureDelete(sessionFile) }
-        }
+        // Session dosyası mekanizması artık kullanılmıyor.
+        // "Asla" kilit: arka plan koruması process'in bellekte canlı olmasına dayanır,
+        // kalıcı dosyaya değil. Mevcut dosya varsa güvenlik gereği temizle.
+        @Suppress("UNUSED_PARAMETER")
+        if (sessionFile.exists()) runCatching { secureDelete(sessionFile) }
     }
 
     private fun writeSessionDek(plaintextDek: ByteArray) {

--- a/composeApp/src/jvmCommonMain/kotlin/app/stade/security/FileVault.kt
+++ b/composeApp/src/jvmCommonMain/kotlin/app/stade/security/FileVault.kt
@@ -37,7 +37,8 @@ class FileVault(private val rootDir: File) : Vault {
         var failedAttempts: Int,
         var lockoutUntilMillis: Long,
         var scrambleKeypad: Boolean,
-        var sessionTimeoutSeconds: Int
+        var sessionTimeoutSeconds: Int,
+        var screenshotBlocking: Boolean = false
     )
 
     override fun isInitialized(): Boolean = metaFile.exists() && metaFile.length() >= MIN_META_SIZE
@@ -256,6 +257,16 @@ class FileVault(private val rootDir: File) : Vault {
         syncSessionFile(meta)
     }
 
+    override fun isScreenshotBlockingEnabled(): Boolean =
+        (cached ?: readMeta())?.screenshotBlocking ?: false
+
+    override fun setScreenshotBlockingEnabled(enabled: Boolean) {
+        val meta = readMeta() ?: return
+        meta.screenshotBlocking = enabled
+        writeMeta(meta)
+        cached = meta
+    }
+
     override fun failedAttempts(): Int = (cached ?: readMeta())?.failedAttempts ?: 0
 
     override fun lockoutUntilMillis(): Long = (cached ?: readMeta())?.lockoutUntilMillis ?: 0L
@@ -340,7 +351,8 @@ class FileVault(private val rootDir: File) : Vault {
     private fun readMeta(): Meta? {
         if (!metaFile.exists()) return null
         val bytes = runCatching { metaFile.readBytes() }.getOrNull() ?: return null
-        if (bytes.size < MIN_META_SIZE) return null
+        // MIN_META_SIZE - 1 = eski vault formatı (screenshotBlocking baytı olmadan); geriye dönük uyum
+        if (bytes.size < MIN_META_SIZE - 1) return null
         val buf = ByteBuffer.wrap(bytes)
         val magic = ByteArray(4).also { buf.get(it) }
         if (!magic.contentEquals(META_MAGIC)) return null
@@ -356,6 +368,7 @@ class FileVault(private val rootDir: File) : Vault {
         val lockoutUntil = buf.long
         val scramble = buf.get() != 0.toByte()
         val timeout = buf.int
+        val screenshot = if (buf.hasRemaining()) buf.get() != 0.toByte() else false
         return Meta(
             salt = salt,
             iterations = iterations,
@@ -366,7 +379,8 @@ class FileVault(private val rootDir: File) : Vault {
             failedAttempts = failed,
             lockoutUntilMillis = lockoutUntil,
             scrambleKeypad = scramble,
-            sessionTimeoutSeconds = timeout
+            sessionTimeoutSeconds = timeout,
+            screenshotBlocking = screenshot
         )
     }
 
@@ -386,6 +400,7 @@ class FileVault(private val rootDir: File) : Vault {
         buf.putLong(meta.lockoutUntilMillis)
         buf.put(if (meta.scrambleKeypad) 1.toByte() else 0.toByte())
         buf.putInt(meta.sessionTimeoutSeconds)
+        buf.put(if (meta.screenshotBlocking) 1.toByte() else 0.toByte())
         val tmp = File(metaFile.parentFile, metaFile.name + ".tmp")
         tmp.writeBytes(out)
         if (metaFile.exists()) metaFile.delete()
@@ -507,7 +522,7 @@ class FileVault(private val rootDir: File) : Vault {
         private val SESSION_MAGIC = byteArrayOf('S'.code.toByte(), 'T'.code.toByte(), 'D'.code.toByte(), 'S'.code.toByte())
         private const val SESSION_VERSION: Byte = 0x01
         private const val MIN_META_SIZE =
-            4 + 1 + SALT_LEN + 4 + NONCE_LEN + VERIFIER_CT_LEN + NONCE_LEN + DEK_CT_LEN + 4 + 8 + 1 + 4
+            4 + 1 + SALT_LEN + 4 + NONCE_LEN + VERIFIER_CT_LEN + NONCE_LEN + DEK_CT_LEN + 4 + 8 + 1 + 4 + 1
         private val VERIFIER_PLAIN = byteArrayOf(
             'S'.code.toByte(), 'T'.code.toByte(), 'A'.code.toByte(), 'D'.code.toByte(),
             'E'.code.toByte(), '-'.code.toByte(), 'V'.code.toByte(), 'E'.code.toByte(),


### PR DESCRIPTION
This pull request introduces a new privacy feature for Android: the ability to block screenshots and hide app content in the recent apps view, controlled via a toggle in the security settings. It also improves the user experience by preserving scroll positions in settings screens and enhances the UI and localization for new privacy options. 

The most important changes are:

**Privacy Feature: Screenshot Blocking**
* Added a new privacy toggle in the security settings (`SecuritySettingsScreen.kt`) to enable or disable screenshot blocking, which uses Android's `FLAG_SECURE` to prevent screenshots and hide content in the recents view. The toggle only appears on platforms that support this feature (currently Android). [[1]](diffhunk://#diff-1a19d589c1d609b549c612b19ac399d139312e831c83bf9e9b2610ddd66f1701L101-R165) [[2]](diffhunk://#diff-1a19d589c1d609b549c612b19ac399d139312e831c83bf9e9b2610ddd66f1701L133-R192) [[3]](diffhunk://#diff-d312feb82879142254a25477cef6db5fc92d21da09d5efa13c1ef4cba3ce021aR1-R13) [[4]](diffhunk://#diff-860c8020ee489777f0cc1105e49a9c407a710650c5926ea498a27ee5b2cbb8f3R1-R5)
* Implemented platform detection for privacy features with an `expect/actual` mechanism, allowing future extensibility for desktop privacy features. [[1]](diffhunk://#diff-d312feb82879142254a25477cef6db5fc92d21da09d5efa13c1ef4cba3ce021aR1-R13) [[2]](diffhunk://#diff-860c8020ee489777f0cc1105e49a9c407a710650c5926ea498a27ee5b2cbb8f3R1-R5)

**Android Integration**
* Integrated the screenshot blocking feature into `MainActivity`, applying or removing `FLAG_SECURE` based on the new setting whenever the activity is created or resumed, preventing unnecessary flag changes to avoid UI flicker. [[1]](diffhunk://#diff-9b7241947c80d4c724375acfd8ec46bc3e56d868710cb359e6a8ac38718fa5efR9) [[2]](diffhunk://#diff-9b7241947c80d4c724375acfd8ec46bc3e56d868710cb359e6a8ac38718fa5efR34) [[3]](diffhunk://#diff-9b7241947c80d4c724375acfd8ec46bc3e56d868710cb359e6a8ac38718fa5efR49-R70)
* Updated the build configuration to ensure `compose.material3` is available for UI components.

**Security and Settings Infrastructure**
* Extended the `Vault` interface and `SecretStore` to support getting and setting the screenshot blocking preference, making it accessible throughout the app. [[1]](diffhunk://#diff-b5aed31db597df514ef61d20a651e943c2f2fe30eede7531854f9aa2bedaf0a9R19-R20) [[2]](diffhunk://#diff-6c30aed68fcbd04f68ff3d65f3bc9a47a06641d0455e6a4a3c584e9eb0750b83R35-R38)

**UI/UX Improvements**
* Preserved scroll positions in settings and security screens, so users returning from sub-screens (like Security → Settings → Security) maintain their previous scroll position. [[1]](diffhunk://#diff-6c403445d7e4f570432623304a23b0cf52ff0057a8aa00977c6d46a6a0c0870eR38) [[2]](diffhunk://#diff-6c403445d7e4f570432623304a23b0cf52ff0057a8aa00977c6d46a6a0c0870eR130-R131) [[3]](diffhunk://#diff-6c403445d7e4f570432623304a23b0cf52ff0057a8aa00977c6d46a6a0c0870eL234-R238) [[4]](diffhunk://#diff-8c38bb690ab72e7fe248bec2139ff6ada9f5ecaac9aea2ecfc213740b4f15db0R19) [[5]](diffhunk://#diff-8c38bb690ab72e7fe248bec2139ff6ada9f5ecaac9aea2ecfc213740b4f15db0R113-R114) [[6]](diffhunk://#diff-8c38bb690ab72e7fe248bec2139ff6ada9f5ecaac9aea2ecfc213740b4f15db0L396-R400)
* Enhanced the security settings UI with better grouping, background styling, and an info dialog for the "Never" auto-lock option. [[1]](diffhunk://#diff-1a19d589c1d609b549c612b19ac399d139312e831c83bf9e9b2610ddd66f1701L101-R165) [[2]](diffhunk://#diff-1a19d589c1d609b549c612b19ac399d139312e831c83bf9e9b2610ddd66f1701L133-R192)

**Localization**
* Added English and Turkish translations for all new privacy-related UI strings, including section headers and subtitles for the screenshot blocking feature. [[1]](diffhunk://#diff-1d47c2d3e45e7bd08553a70fe6dedc7e2b48c4aaabf683688a324ec73e85da7aR171-R178) [[2]](diffhunk://#diff-bfb2d069f5a1dae7fb63f4391e02680d7a964d176600c6d79f4a20439af65d9aR214-R224) [[3]](diffhunk://#diff-70fb5fb596200fe340356e9c78660b07de5053de7347a3ab8c098dbd04e512ecR215-R225)